### PR TITLE
sfos-patch-keyboard-for-long-phones: 4.2 update

### DIFF
--- a/sfos-patch-keyboard-for-long-phones/CONFIG
+++ b/sfos-patch-keyboard-for-long-phones/CONFIG
@@ -13,7 +13,7 @@
 #
 
 SourcePackages:
-- jolla-keyboard >= 0.7.13
+- jolla-keyboard >= 0.8.26
 
 Prefix: /usr/share
 DisplayName: Keyboard adapted to 'long' phones (like Xperia 10)
@@ -46,12 +46,12 @@ DiscussionLink: https://openrepos.net/content/ichthyosaurus/patch-keyboard-adapt
 # DonationsLink: still missing
 SourcesLink: https://github.com/ichthyosaurus/sailfish-public-patch-sources
 
-Version: 1.0.1
+Version: 1.0.2
 Release: 1
 
 Requires:
-- sailfish-version >= 3.0.0
-- jolla-keyboard >= 0.7.13
+- sailfish-version >= 4.2.0
+- jolla-keyboard >= 0.8.26
 
 # Conflicts:
 # - my-conflicting-package = 0.0.1
@@ -61,14 +61,19 @@ Screenshots:
 - screenshot-02-patched.png
 
 CompatibleVersions:
-- 3.2.1.20
-- 3.3.0.14
-- 3.3.0.16
-- 3.4.0.22
-- 3.4.0.24
+# 3.2.1.20
+# 3.3.0.14
+# 3.3.0.16
+# 3.4.0.22
+# 3.4.0.24
+- 4.2.0.21
 
 
 Changelog:
+- 1.0.2:
+- - update compatibility info: the patch is compatible with SailfishOS 4.2
+- - tie offset to screen height not keyboard height
+-
 - 1.0.1:
 - - update compatibility info: the patch is compatible with all versions of SailfishOS up to 3.4.0.24
 -

--- a/sfos-patch-keyboard-for-long-phones/unified_diff.patch
+++ b/sfos-patch-keyboard-for-long-phones/unified_diff.patch
@@ -1,13 +1,21 @@
-diff --git a/usr/share/maliit/plugins/com/jolla/KeyboardBase.qml b/usr/share/maliit/plugins/com/jolla/KeyboardBase.qml
-index 9f98394..5cdc2f2 100644
---- a/usr/share/maliit/plugins/com/jolla/KeyboardBase.qml
-+++ b/usr/share/maliit/plugins/com/jolla/KeyboardBase.qml
-@@ -92,7 +92,7 @@ SwipeGestureArea {
+diff -Naur /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml
+--- /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml	2021-10-15 13:18:03.545697852 +0200
++++ /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml	2021-10-27 18:43:05.706339880 +0200
+@@ -71,6 +71,8 @@
+     property bool closeSwipeActive
+     property int closeSwipeThreshold: Math.max(currentLayoutHeight*.3, Theme.itemSizeSmall)
  
-     readonly property bool swipeGestureIsSafe: !releaseTimer.running
++    property real longphoneoffset: Screen.height * 0.12
++
+     readonly property real currentLayoutHeight: layout ? layout.height : 2 * Theme.itemSizeHuge
+     readonly property real minimumLayoutHeight: {
+         var height = currentLayoutHeight
+@@ -113,7 +115,7 @@
+         readonly property bool current: status === Loader.Ready && PagedView.isCurrentItem
  
--    height: layout ? layout.height : 0
-+    height: layout ? (portraitMode ? layout.height*1.25 : layout.height) : 0
-     onLayoutChanged: if (layout) layout.parent = keyboard
-     onPortraitModeChanged: cancelAllTouchPoints()
+         width: keyboard.width
+-        height: status === Loader.Error ? Theme.itemSizeHuge : implicitHeight
++        height: status === Loader.Error ? Theme.itemSizeHuge : (portraitMode ? implicitHeight + longphoneoffset  : implicitHeight )
+ 
+         source: keyboard.sourceDirectory + model.file
  

--- a/sfos-patch-keyboard-for-long-phones/unified_diff.patch
+++ b/sfos-patch-keyboard-for-long-phones/unified_diff.patch
@@ -1,6 +1,6 @@
 diff -Naur /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml
 --- /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml	2021-10-15 13:18:03.545697852 +0200
-+++ /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml	2021-10-27 18:43:05.706339880 +0200
++++ /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml	2021-10-27 19:20:31.397447436 +0200
 @@ -71,6 +71,8 @@
      property bool closeSwipeActive
      property int closeSwipeThreshold: Math.max(currentLayoutHeight*.3, Theme.itemSizeSmall)
@@ -15,7 +15,7 @@ diff -Naur /usr/share/maliit/plugins/com/jolla/KeyboardBase.qml
  
          width: keyboard.width
 -        height: status === Loader.Error ? Theme.itemSizeHuge : implicitHeight
-+        height: status === Loader.Error ? Theme.itemSizeHuge : (portraitMode ? implicitHeight + longphoneoffset  : implicitHeight )
++        height: status === Loader.Error ? Theme.itemSizeHuge : (portraitMode ? implicitHeight + longphoneoffset : implicitHeight)
  
          source: keyboard.sourceDirectory + model.file
  


### PR DESCRIPTION
make the patch compatible with SailfishOS 4.2
tie offset to screen height not keyboard height

Note: 1.0.1 does work as intended  with SFOS 4.0 and 4.1 but I don't have the jolla-keyboard version available to set the dependency.